### PR TITLE
Improve the script in multiple ways

### DIFF
--- a/mouse-natural-scroll.ps1
+++ b/mouse-natural-scroll.ps1
@@ -1,40 +1,54 @@
-Write-Host "Finding your USB mouse..." -ForegroundColor Cyan
+# Enable natural scrolling for all configured USB mice on the system - pulling
+# down the mouse wheel pulls the screen area down, showing the text above.
+#
+# Use the "reverse" argument to enable unnatural a.k.a. Microsoft default
+# scrolling - pulling down the mouse wheel shows the text below.
+#
+# Run this script in PowerShell as administrator.
+#
+# The mouse behavior changes only after rebooting the system.
 
-$mouses = Get-PnpDevice -Class Mouse
-if (!$mouses) {
-    Write-Host -ForegroundColor Red "Could not find your USB mouse"
+$setting_names = @("DEFAULT", "NATURAL")
+
+if ($args[0] -eq "reverse") {
+    $target_setting = 0
+} else {
+    $target_setting = 1
+}
+
+$mice = Get-PnpDevice -Class Mouse
+if (!$mice) {
+    Write-Host -ForegroundColor Red "Could not find any USB mouse"
     exit 1
 }
 
 # set up every mouse
-foreach ($mouse in $mouses) {
+foreach ($mouse in $mice) {
     $name = $mouse.FriendlyName
     $path = $mouse.InstanceID
 
     if (!($path -like "HID\VID*")) {
-        Write-Host -ForegroundColor Yellow "Skipping"$path
+        Write-Host "Not a compatible mouse, skipping: $name ($path)"
         continue
     }
-    Write-Host -ForegroundColor Blue "We have"$path
 
-    Write-Host "Found $name ($path)" -ForegroundColor Green
-    Write-Host "Configuring natural scrolling feature for your mouse..." -ForegroundColor Cyan
-
-    # check if we have admin
-    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-    if (!$currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-        Write-Host -ForegroundColor Red "Need admin privilege to modify the registry"
-        exit 1
-    }
+    Write-Host "Found $name ($path)"
 
     # the reg path has changed since win11
     $reg_path = "HKLM:\SYSTEM\CurrentControlSet\Enum\$path\Device Parameters"
 
-    if ($args[0] -eq "reverse") {
-        Set-ItemProperty -Path $reg_path -Name FlipFlopWheel -Value 0
-        Write-Host "Natural scrolling feature for your mouse has been DISABLED" -ForegroundColor Green
+    $current_setting = (Get-ItemProperty -Path $reg_path -Name FlipFlopWheel).FlipFlopWheel
+
+    if ($current_setting -ne $target_setting) {
+        # Check if we have admin rights
+        $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+        if (!$currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+             Write-Host -ForegroundColor Red "Need admin privilege to modify the registry"
+             exit 1
+        }
+        Set-ItemProperty -Path $reg_path -Name FlipFlopWheel -Value $target_setting
+        Write-Host -ForegroundColor Green "Scrolling setting has been set to" $setting_names[$target_setting]
     } else {
-        Set-ItemProperty -Path $reg_path -Name FlipFlopWheel -Value 1
-        Write-Host "Natural scrolling feature for your mouse has been ENABLED" -ForegroundColor Green
+        Write-Host "Keeping the current scrolling setting:" $setting_names[$current_setting]
     }
 }


### PR DESCRIPTION
Add a detailed comment in the beginning to make the script useful even without documentation.

Use user friendly names for the settings, DEFAULT and NATURAL instead of 0 and 1.

Don't attempt to change settings that are already what the user requested.

Don't overuse colors, only use red for errors and green for changes. Blue is hard to read on the default blue background. Remove excessive messages.

Replace "mouses" variable with "mice".

Explain why some mice are skipped (they are incompatible, e.g. touchpads).

Always print name and path of the mouse, not just path.